### PR TITLE
Several AI fixes

### DIFF
--- a/dlls/entities/base/CCineMonster.cpp
+++ b/dlls/entities/base/CCineMonster.cpp
@@ -377,7 +377,6 @@ void CCineMonster::PossessEntity(void)
             pTarget->pev->avelocity = Vector(0, 0, 0);
             pTarget->pev->velocity = Vector(0, 0, 0);
             pTarget->pev->effects |= EF_NOINTERP;
-            pTarget->pev->angles.y = pev->angles.y;
             pTarget->m_scriptState = SCRIPT_WAIT;
             //m_startTime = gpGlobals->time + 1E6;
             break;
@@ -386,6 +385,12 @@ void CCineMonster::PossessEntity(void)
             pTarget->m_scriptState = SCRIPT_WAIT;
             break;
         }
+
+        /* handle instant turn */
+        if (m_fMoveTo == 4 || m_fMoveTo == 6) {
+            pTarget->pev->angles.y = pev->angles.y;
+        }
+
         //        ALERT( at_aiconsole, "\"%s\" found and used (INT: %s)\n", STRING( pTarget->pev->targetname ), FBitSet(pev->spawnflags, SF_SCRIPT_NOINTERRUPT)?"No":"Yes" );
 
         pTarget->m_IdealMonsterState = MONSTERSTATE_SCRIPT;

--- a/dlls/entities/base/CCineMonster.cpp
+++ b/dlls/entities/base/CCineMonster.cpp
@@ -576,8 +576,11 @@ void ScriptEntityCancel(edict_t* pentCine)
     // make sure they are a scripted_sequence
     if (FClassnameIs(pentCine, "scripted_sequence") || FClassnameIs(pentCine, "scripted_action"))
     {
-        ((CCineMonster*)VARS(pentCine))->m_iState = STATE_OFF;
         CCineMonster* pCineTarget = GetClassPtr((CCineMonster*)VARS(pentCine));
+        if (!pCineTarget->pev)
+            return;
+        pCineTarget->m_iState = STATE_OFF;
+
         // make sure they have a monster in mind for the script
         CBaseEntity* pEntity = pCineTarget->m_hTargetEnt;
         CBaseMonster* pTarget = NULL;


### PR DESCRIPTION
Some move commands incorrectly assume the entity wants to be turned instantly, this hotfix resolves that issue entirely.

This PR also fixes an issue where some NPCs would teleport randomly when getting hit, killed. There was a heap corruption caused by unchecked state write in CCineMonster.ccp's ScriptEntityCancel, where the entity's data was already de-allocated but we still wrote to it. We simply check if `pev` is still valid before writing any state changes, which resolves the corruption issue and monsters no longer act incorrectly.

I also have some fixes for scripted_action available, but those are mostly related to missing Spirit code in the Schedule and DefaultAI sources that would normally provide such features. Let me know if I should integrate those as well.