### PR TITLE
Fix a crash of SwitchWeapon

### DIFF
--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -5104,8 +5104,16 @@ BOOL CBasePlayer :: SwitchWeapon( CBasePlayerItem *pWeapon )
 		m_pActiveItem->UpdateItemInfo( );
 	}
 #else
-	m_pActiveItem = pWeapon;
-	pWeapon->Deploy( );
+	if (pWeapon != nullptr)
+	{
+		m_pActiveItem = pWeapon;
+		pWeapon->Deploy();
+	}
+	else if (m_pLastItem != nullptr)
+	{
+		m_pActiveItem = m_pLastItem;
+		m_pLastItem->Deploy();
+	}
 #endif
 	return TRUE;
 }

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -5104,15 +5104,11 @@ BOOL CBasePlayer :: SwitchWeapon( CBasePlayerItem *pWeapon )
 		m_pActiveItem->UpdateItemInfo( );
 	}
 #else
-	if (pWeapon != nullptr)
+	m_pActiveItem = pWeapon;
+
+	if (pWeapon)
 	{
-		m_pActiveItem = pWeapon;
 		pWeapon->Deploy();
-	}
-	else if (m_pLastItem != nullptr)
-	{
-		m_pActiveItem = m_pLastItem;
-		m_pLastItem->Deploy();
 	}
 #endif
 	return TRUE;


### PR DESCRIPTION
When SwitchWeapon's "pWeapon" argument is nullptr, try to switch to last item. If last item is nullptr too, don't do anything. At least don't crash.