### PR TITLE
Fix monster being invisible and non-solid after it gets teleported by the scripted sequence

### DIFF
--- a/dlls/schedule.cpp
+++ b/dlls/schedule.cpp
@@ -1379,6 +1379,8 @@ void CBaseMonster::StartTask(Task_t* pTask)
 
 			if (m_pCine->m_fMoveTo != 6)
 				pev->origin = m_pGoalEnt->pev->origin;
+			if (m_pCine->m_fMoveTo == 4)
+				UTIL_SetOrigin(this, pev->origin);
 		}
 
 		TaskComplete();


### PR DESCRIPTION
The monster doesn't get relinked to the world so it's still non-solid in the new position. Also if the old position of the monster is not in player's PVS the monster will be invisible to the player.

Here's the test map that reproduces the bug [teleseqtest.zip](https://github.com/user-attachments/files/23675562/teleseqtest.zip)
