### PR TITLE
Fix seamless teleport causing the player camera tilting to right or left

### DIFF
--- a/dlls/triggers.cpp
+++ b/dlls/triggers.cpp
@@ -4757,6 +4757,7 @@ void CTriggerTeleport::TeleportTouch(CBaseEntity* pOther)
 			{
 				//				ALERT(at_console, "v_angle = %f %f %f\n", pOther->pev->v_angle.x, pOther->pev->v_angle.y, pOther->pev->v_angle.z);
 				pOther->pev->angles.x = pOther->pev->v_angle.x;
+				pOther->pev->angles.z = pOther->pev->v_angle.z = 0;
 				//				pOther->pev->v_angle.y += ydiff;
 				pOther->pev->fixangle = true;
 			}


### PR DESCRIPTION
The anniversary update added the rollangle value which is messing up the player's camera when going through seamless teleport (especially if you do it sideways).