### PR TITLE
Fix CRenderFxFader save-restore

### DIFF
--- a/dlls/triggers.cpp
+++ b/dlls/triggers.cpp
@@ -1793,6 +1793,7 @@ public:
 
 	int m_iszAmtFactor;
 };
+LINK_ENTITY_TO_CLASS(render_fader, CRenderFxFader);
 
 TYPEDESCRIPTION CRenderFxFader::m_SaveData[] =
 	{
@@ -1813,6 +1814,7 @@ IMPLEMENT_SAVERESTORE(CRenderFxFader, CBaseEntity);
 void CRenderFxFader::Spawn()
 {
 	SetThink(&CRenderFxFader::FadeThink);
+	pev->classname = MAKE_STRING("render_fader");
 }
 
 void CRenderFxFader::FadeThink()


### PR DESCRIPTION
`CRenderFxFader` wasn't even linked to the classname, so it wasn't saved. I come up with a `render_fader` name. Since `CRenderFxFader` is created by `GetClassPtr` we also have to explicitly set the classname in the `Spawn`.