### PR TITLE
Small code fixes for calc_numfroment and watcher/multi_watcher

### DIFF
--- a/dlls/locus.cpp
+++ b/dlls/locus.cpp
@@ -933,7 +933,7 @@ bool CCalcNumFromEnt::CalcNumber(CBaseEntity* pLocus, float* OUTresult)
 		return false;
 	}
 
-	CBaseEntity* target = UTIL_FindEntityByTargetname(NULL, STRING(pev->target));
+	CBaseEntity* target = UTIL_FindEntityByTargetname(NULL, STRING(pev->target), pLocus);
 	if (target)
 	{
 		if (pev->impulse == 0)

--- a/dlls/triggers.cpp
+++ b/dlls/triggers.cpp
@@ -1282,7 +1282,7 @@ bool CStateWatcher::EvalLogic(CBaseEntity* pActivator)
 				b = true;
 			break;
 		case STATE_TURN_OFF:
-			if (pev->spawnflags & SF_SWATCHER_TURN_ON)
+			if (pev->spawnflags & SF_SWATCHER_TURN_OFF)
 				b = true;
 			break;
 		case STATE_IN_USE:


### PR DESCRIPTION
Small code fixes. locus.cpp should be nonbreaking. Activator was not passed through to `UTIL_FindEntityByTargetname` inside `calc_numfroment`
triggers.cpp could maybe break maps where turnoff watcher was relied on without the appropriate flag. (If such exist)